### PR TITLE
Added basic CSS grid properties (resolves #7)

### DIFF
--- a/src/cssProperties.js
+++ b/src/cssProperties.js
@@ -170,7 +170,13 @@ const properties = [
     'visibility',
     'cursor',
     'box-shadow',
-    'box-sizing'
+    'box-sizing',
+    'grid-template-columns',
+    'grid-template-rows',
+    'grid-row-start',
+    'grid-column-start',
+    'grid-row-end',
+    'grid-column-end'
 ];
 
 let propertyMap = {};


### PR DESCRIPTION
## Addition
I added these CSS properties to src/cssProperties.js
```
grid-template-columns
grid-template-rows
grid-row-start
grid-column-start
grid-row-end
grid-column-end
```

## Example Code
```nazca
.html {
    .body {
        .div {
            display: grid;
            grid-template-columns: 1fr 1fr;
            grid-template-rows: 1fr 1fr;

            .div {
                text: 1, 1;
            };
            .div {
                text: 1, 2;
            };
            .div {
                text: 2, 1;
            };
            .div {
                text: 2, 2;
            };
        };
    };
};
```

## Result
![image](https://user-images.githubusercontent.com/40712686/141578729-ba9e4194-27df-4a3d-a900-abc61dbed8fe.png)
